### PR TITLE
Modifiers as pre-postconditions and abstraction

### DIFF
--- a/conclusions.tex
+++ b/conclusions.tex
@@ -1,17 +1,24 @@
 \section{Conclusion}
 \label{section:conclusion}
-We have presented our work in progress building an SMT-based formal
-verification module inside the Solidity compiler.
+We have presented our current work and future plans building an SMT-based
+formal verification module inside the Solidity compiler.
 %
-The component creates SMT constraints from the Solidity code and queries to
-statically check for underflow/overflow, division by zero, unreachable/trivial
-code, and assertion fails.
+The module creates SMT constraints from the Solidity code and queries SMT
+solvers to statically check for underflow/overflow, division by zero,
+unreachable/trivial code, and assertion fails, where require statements are
+used as assumptions.
 %
 The programmer receives, in compile-time, feedback with counterexamples in case
 any of the target properties fail, without any extra effort.
+%
+The SMT constraints and queries are created using theories that model the
+Solidity program precisely, therefore the given counterexamples are correct.
 
-Our under implementation features intend to extend the subset of Solidity that
-is supported, and future work includes interesting research questions, such as
-computing multi-transaction invariants for state variables, and using
-properties from assertions at the end of functions or from modifiers to compute
-generic invariants, as discussed in Sec.~\ref{section:smt}.
+The features that are currently under implementation aim at extending the
+subset of Solidity that is supported, which need new theories, as well as
+improving error reporting.
+%
+Future work on the SMT module includes interesting broader research questions,
+such as computing multi-transaction invariants for state variables, detecting
+post-constructor invariants, and using modifier-based abstraction for
+functions.

--- a/smt_fv.tex
+++ b/smt_fv.tex
@@ -194,7 +194,7 @@ Even though the current implementation of the SMT module supports a small
 subset of Solidity, it can already be used to detect flaws that might be
 overlooked by the user.
 %
-We shorty present now a few examples of buggy code that the compiler is able to
+We present now a few examples of buggy code that the compiler is able to
 detect regarding constant conditions, overflow, and assertion checking.
 
 The following loop is infinite because the author of the code
@@ -252,9 +252,12 @@ function f(bool a, bool b) public pure {
     if (b) c = true;
     else c = false;
   }
-  assert(c == ((a && !b) || (!a && b)));
+  assert(c != ((a && !b) || (!a && b)));
 }
 \end{verbatim}
+
+Note that the assertion is incorrect, where the correct assertion is
+\code{assert(c == ((a \&\& !b) || (!a \&\& b)));}.
 
 \subsection{Future Plans}
 

--- a/smt_fv.tex
+++ b/smt_fv.tex
@@ -194,11 +194,11 @@ Even though the current implementation of the SMT module supports a small
 subset of Solidity, it can already be used to detect flaws that might be
 overlooked by the user.
 %
-We present now a few examples of buggy code that the compiler is already able
-to detect.
+We present now a few examples of buggy code that the compiler is able to
+detect.
 
 The following loop is infinite because the author of the code
-forget to increment the loop variablee \code{i}.
+forgot to increment the loop variablee \code{i}.
 %
 In that case, the user receives a message about the loop's condition being
 always true for the case where \code{owners.length} is not zero.
@@ -210,8 +210,8 @@ for (uint i = 0; i < owners.length;)
 }
 \end{verbatim}
 
-Another type of problem that the compiler already finds automatically is
-unreachable code.
+Another type of problem that the compiler finds automatically is unreachable
+code.
 %
 In the following control-flow expressions, it warns the user that the condition
 in the \code{else if} is unreachable.
@@ -387,25 +387,57 @@ contract.
 Similarly to the previous example, it is not possible to prove the last
 assertion without the knowledge about the invariant.
 
-
 \end{paragraph}
 
-\begin{paragraph}{Modifiers as pre-postconditions.}
-A feature that promises to help the computation of state variable invariants
-(discussed above) is pre and postconditions for functions.
-%
-The first challenge is finding a good syntax to represent the conditions.
+\begin{paragraph}{Modifiers as pre and postconditions.}
+An orthogonal approach to automatically inferred invariants is to provide a
+good syntax so that Solidity programmers can explicitly state pre and
+postconditions of functions.
 %
 Modifiers (Sec.\ref{section:solidity}) are a natural candidate for that, given
 their ability to behave as patterns that wrap functions.
 %
-The modifier \code{onlyOwner} introduced in Sec.~\ref{section:solidity} acts
-exactly as a precondition for any function that uses it, therefore we can
-encode it as the predicate $onlyOwner(f)$ which is conjoined with the encoding
-of function \code{f}.
+In the following code, the modifier \code{safeBalance} states pre and
+postconditions for the \code{transfer} function in the \code{Token} contract
+(Sec.~\ref{section:solidity}), ensuring that the concrete value of
+\code{totalSupply} does not change after a token transfer.
+
+\begin{verbatim}
+modifier safeBalance {
+  require(totalSupply == 10000);
+  _;
+  assert(totalSupply == 10000);
+}
+
+function transfer(address _to, uint256 _value) safeBalance {
+  ...
+}
+\end{verbatim}
+\end{paragraph}
+
+\begin{paragraph}{Function abstraction.}
+An implication of the usage of modifiers as pre and postconditions, as
+described above, is the possibility of modifier-based function abstraction.
 %
-With this feature we intend to compute functions pre and postconditions
-automatically.
+Let \code{zeroAccount} be a function from contract \code{Token} that transfers
+all the tokens that an account holds to another one of their choice.
+%
+Function \code{zeroAccount} should also be sure that the \code{totalSupply} did
+not change.
+
+\begin{verbatim}
+function zeroAccount(address _to) {
+  transfer(_to, balance[msg.sender]);
+  assert(totalSupply == 10000);
+}
+\end{verbatim}
+
+One approach to analyze \code{zeroAccount} is to abstract function
+\code{transfer} by encoding only its modifiers and ignoring its body when
+trying to prove the assertion.
+%
+This query is much cheaper for the SMT solver, and in many cases (as it is in
+this one) it might be enough to prove the assertion.
 \end{paragraph}
 
 \begin{paragraph}{Effective Callback Freeness.}

--- a/smt_fv.tex
+++ b/smt_fv.tex
@@ -227,10 +227,11 @@ parameters of public functions are used.
 The code below may easily lead to an overflow, which the tool reports with a
 counterexample.
 %
-The overflow can be fixed with a \code{require} statement.
+The overflow can be prevented with a \code{require} statement.
 
 \begin{verbatim}
 function addFunds(uint256 _amount) {
+  // require(_amount < 1000000 && funds < 1000000);
   funds += _amount;
 }
 \end{verbatim}
@@ -238,8 +239,9 @@ function addFunds(uint256 _amount) {
 One of the most important features is the ability to check safety properties
 statically, by using Solidity's \code{assert}.
 %
-The following example code uses an \code{assert} to check the correctness of an
-$xor$ operation written as control-flow.
+The following example code uses an \code{assert} to check the equivalence of
+two computations, once written using control-flow statements, once as a direct
+Boolean formula.
 
 \begin{verbatim}
 function f(bool a, bool b) public pure {
@@ -256,7 +258,10 @@ function f(bool a, bool b) public pure {
 }
 \end{verbatim}
 
-Note that the assertion is incorrect, where the correct assertion is
+Note that the assertion will be reported to fail with the valuation
+\code{a = false, b = false, c = false}.
+%
+The safe condition would be
 \code{assert(c == ((a \&\& !b) || (!a \&\& b)));}.
 
 \subsection{Future Plans}
@@ -452,8 +457,8 @@ function transfer(address _to, uint256 _value) safeBalance {
 \end{paragraph}
 
 \begin{paragraph}{Function abstraction.}
-An implication of the usage of modifiers as pre and postconditions, as
-described above, is the possibility of modifier-based function abstraction.
+If modifiers are used as pre and postconditions as described above, it could be
+possible to abstract functions based on these modifiers.
 %
 Let \code{zeroAccount} be a function from contract \code{Token} that transfers
 all the tokens that an account holds to another one of their choice.
@@ -480,11 +485,14 @@ this one) it might be enough to prove the assertion.
 The idea of \emph{Effective Callback Freeness} was recently introduced by
 \cite{Grossman}.
 %
-A smart contract $C$ is effectively callback free, if its internal callbacks do
-not modify any state variables.
+A smart contract $C$ is effectively callback free, if any state change caused
+by a callback in $C$ can also be caused by an execution that does not have this
+callback.
 %
-A straightforward example is a contract that uses a mutex mechanism to disallow
-state changes if the function is called as a callback.
+Straightforward examples include a contract that uses a mutex mechanism to
+disallow state changes if the function is called as a callback, and the general
+pattern where all functions perform state changes before they call other
+contracts.
 %
 The authors show that most of the contracts deployed on Ethereum have this
 property.

--- a/smt_fv.tex
+++ b/smt_fv.tex
@@ -194,8 +194,8 @@ Even though the current implementation of the SMT module supports a small
 subset of Solidity, it can already be used to detect flaws that might be
 overlooked by the user.
 %
-We present now a few examples of buggy code that the compiler is able to
-detect.
+We shorty present now a few examples of buggy code that the compiler is able to
+detect regarding constant conditions, overflow, and assertion checking.
 
 The following loop is infinite because the author of the code
 forgot to increment the loop variablee \code{i}.
@@ -221,7 +221,40 @@ if (a >= 7) { ... }
 else if (a >= 10) { ... }
 \end{verbatim}
 
-\todo{maybe another example, using require/assert}
+Arithmetic operations should be checked against overflow, especially when
+parameters of public functions are used.
+%
+The code below may easily lead to an overflow, which the tool reports with a
+counterexample.
+%
+The overflow can be fixed with a \code{require} statement.
+
+\begin{verbatim}
+function addFunds(uint256 _amount) {
+  funds += _amount;
+}
+\end{verbatim}
+
+One of the most important features is the ability to check safety properties
+statically, by using Solidity's \code{assert}.
+%
+The following example code uses an \code{assert} to check the correctness of an
+$xor$ operation written as control-flow.
+
+\begin{verbatim}
+function f(bool a, bool b) public pure {
+  bool c;
+  if (a) {
+    if (b) c = false;
+    else c = true;
+  }
+  else {
+    if (b) c = true;
+    else c = false;
+  }
+  assert(c == ((a && !b) || (!a && b)));
+}
+\end{verbatim}
 
 \subsection{Future Plans}
 
@@ -444,9 +477,11 @@ this one) it might be enough to prove the assertion.
 The idea of \emph{Effective Callback Freeness} was recently introduced by
 \cite{Grossman}.
 %
-A smart contract $C$ is effectively callback free, if any state change caused
-by an internal callback can also be caused by an execution that does not have this callback.
-\todo{should we rephrase this now that we know more?}
+A smart contract $C$ is effectively callback free, if its internal callbacks do
+not modify any state variables.
+%
+A straightforward example is a contract that uses a mutex mechanism to disallow
+state changes if the function is called as a callback.
 %
 The authors show that most of the contracts deployed on Ethereum have this
 property.

--- a/solidity.tex
+++ b/solidity.tex
@@ -42,7 +42,7 @@ contract Token {
     }
 }
 \end{verbatim}
-\caption{Example of a token contract}
+\caption{Example of a token contract.}
 \label{fig:tokenContract}
 \end{figure}
 
@@ -95,13 +95,14 @@ Commonly used modifiers are, for example, allowing only the owner of the
 contract to execute the function, or executing a function if and only if the
 amount of Ether sent is greater than a certain value.
 %
-The following example shows a contract using the former, where function
-\code{f} is executed if and only if the original deployer of the contract is
-the caller.
+Fig.~\ref{fig:modifiers} shows a contract using the former, where the
+execution of function \code{f} continues if and only if the original deployer
+of the contract is the caller.
 %
 We discuss later how to use modifiers to represent function pre- and
 postconditions.
 
+\begin{figure}
 \begin{verbatim}
 contract C
 {
@@ -124,3 +125,7 @@ contract C
   }
 }
 \end{verbatim}
+\caption{Example of modifiers.}
+\label{fig:modifiers}
+\end{figure}
+


### PR DESCRIPTION
@chriseth I've finally converged on what I wanted to write for the `modifiers as pre-postconditions` and `modifier-based function abstraction` paragraphs. The examples are pretty simple, but I think they give the idea.